### PR TITLE
Navigation / trail endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN python manage.py collectstatic --noinput
 
 EXPOSE 8000
 
-CMD ["gunicorn", "--chdir", "/app/weather", "--bind", "0.0.0.0:8000", "weather.wsgi"]
+CMD ["gunicorn", "--timeout", "120", "--chdir", "/app/weather", "--bind", "0.0.0.0:8000", "weather.wsgi"]

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from .views import get_weather, get_address, get_directions, get_all_trails
+from .views import *
 
 urlpatterns = [
     path('weather/', get_weather),
     path('address/', get_address),
     path('directions/', get_directions),
-    path('activities/trails/all', get_all_trails)
+    path('activities/trails/all', get_all_trails),
+    path('activities/trails/top/', get_top_trails_near_location)
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import get_weather, get_address, get_directions
+from .views import get_weather, get_address, get_directions, get_all_trails
 
 urlpatterns = [
     path('weather/', get_weather),
     path('address/', get_address),
     path('directions/', get_directions),
+    path('activities/trails/all', get_all_trails)
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1,14 +1,18 @@
-from django.shortcuts import render
 import requests
 import platform
 import xml.etree.ElementTree as ET
 import json
+from datetime import datetime
+
+from django.shortcuts import render
 from django.http import JsonResponse, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.cache import cache_page
 from django.core.serializers import serialize
-from datetime import datetime
+from django.contrib.gis.geos import Point
+from django.contrib.gis.db.models.functions import Distance
 from django.conf import settings
+
 from .models import Trail
 
 @csrf_exempt
@@ -124,3 +128,43 @@ def get_all_trails(request):
         )
         
         return HttpResponse(geojson_data, content_type='application/json')
+    
+@csrf_exempt
+def get_top_trails_near_location(request):
+    """
+    Returns the top 5 trails nearest to a given location.
+    
+    GET parameters:
+      - lat: latitude
+      - lon: longitude
+      
+    For each trail, we compute the distance from the given point to its
+    'route' field (the closest distance) and return the entire DB object
+    (all fields) plus the computed distance.
+    """
+    if request.method != "GET":
+        return JsonResponse({"error": "GET method required"}, status=400)
+
+    lat = request.GET.get("lat")
+    lon = request.GET.get("lon")
+    if not lat or not lon:
+        return JsonResponse({"error": "Both lat and lon parameters are required."}, status=400)
+
+    try:
+        lat = float(lat)
+        lon = float(lon)
+    except ValueError:
+        return JsonResponse({"error": "Invalid lat or lon values."}, status=400)
+
+    user_point = Point(lon, lat, srid=4326)
+
+    trails = Trail.objects.annotate(distance=Distance("route", user_point))\
+                          .order_by("distance")[:5]
+
+    geojson_str = serialize("geojson", trails, geometry_field="route")
+    geojson_data = json.loads(geojson_str)
+
+    for feature, trail in zip(geojson_data["features"], trails):
+        feature["properties"]["distance_m"] = trail.distance.m
+
+    return HttpResponse(json.dumps(geojson_data), content_type="application/json")


### PR DESCRIPTION
Added views for following urls:
- `activities/trails/all` returns all trails in the database.
    - @andradeM17 this needs your testing on the frontend to see if it's actually a viable endpoint to have. The API call takes a few seconds because it's returning the GeoJSON of all the trails containing high resolution StringLines.
    - I have tried to mitigate this by adding caching on the Django side, could implement it client-side as well
    - Alternatively if this slows down the frontend I could return just Points instead of lines
    - Test it at [http://localhost:8000/api/activities/trails/all](http://localhost:8000/api/activities/trails/all)
    
- `activities/trails/top/` returns top 5 nearest trails to a given location
    - Performance here is better although it still takes a few seconds because the DB is calculating the distance.
    - Test it at [http://localhost:8000/api/activities/trails/top/?lat=52.687642&lon=-7.956185](http://localhost:8000/api/activities/trails/top/?lat=52.687642&lon=-7.956185)