### PR TITLE
Activities / Fix loops by skipping Multilinestring

### DIFF
--- a/api/management/commands/import_trails.py
+++ b/api/management/commands/import_trails.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         params = {
-            "where": "1=1",
+            "where": "LengthKm <= 80",
             "outFields": "*",
             "outSR": "4326",  # WGS 84 (EPSG:4326)
             "f": "geojson"
@@ -47,6 +47,7 @@ class Command(BaseCommand):
             elif geom_type == "LineString":
                 geom = LineString(geom_coords)
             elif geom_type == "MultiLineString":
+                continue
                 try:
                     line_strings = [LineString(part) for part in geom_coords if len(part) > 1]
                     if line_strings:

--- a/api/management/commands/import_trails.py
+++ b/api/management/commands/import_trails.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         params = {
-            "where": "LengthKm <= 80",
+            "where": "1=1",
             "outFields": "*",
             "outSR": "4326",  # WGS 84 (EPSG:4326)
             "f": "geojson"


### PR DESCRIPTION
We are simply skipping all multilinestrings so that we don't have to flatten and get wrong geometries.